### PR TITLE
Don't sanitize URL values

### DIFF
--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -459,7 +459,8 @@ class BibtexConverter {
         $value = $entry['niceauthor'];
         $value = $this->authorlink($value);
       }
-      if ( $key == 'bibtex') {
+      // Don't sanitize values associated with bibtex or url keys 
+      if ( $key == 'bibtex' || $key == 'url') {
         $patterns []= '/@'.$key.'@/';
         $replacements []= $value;
       }


### PR DESCRIPTION
Small change to not sanitize URL values. This is necessary to preserve tildes in URLs, common in academic web addresses.